### PR TITLE
Fix NPE issue due to absent of keys and/or href elements.

### DIFF
--- a/src/main/java/org/dita/dost/util/FilterUtils.java
+++ b/src/main/java/org/dita/dost/util/FilterUtils.java
@@ -360,8 +360,14 @@ public class FilterUtils {
 	}
 
 	private void updateJobIfKeyFiltered(Attributes attributes) {
-        if (MAPGROUP_D_KEYDEF.matches(attributes)) {
-            Job.instance.addFilteredKey(attributes.getValue(ATTRIBUTE_NAME_KEYS), attributes.getValue(ATTRIBUTE_NAME_HREF));
+        if (MAPGROUP_D_KEYDEF.matches(attributes)) {        	
+        	if(attributes.getValue(ATTRIBUTE_NAME_KEYS)==null||attributes.getValue(ATTRIBUTE_NAME_HREF)==null) {
+        		if(attributes.getValue(ATTRIBUTE_NAME_KEYREF)==null) {
+        			throw new IllegalArgumentException("Attribute"+ATTRIBUTE_NAME_KEYREF+","+ATTRIBUTE_NAME_KEYS+" or "+ATTRIBUTE_NAME_HREF+" can not be null");
+        		}
+        	}else {
+        		Job.instance.addFilteredKey(attributes.getValue(ATTRIBUTE_NAME_KEYS), attributes.getValue(ATTRIBUTE_NAME_HREF));
+        	}
         }
     }
 


### PR DESCRIPTION
As for topicref and keydef, the class is the same, hence there is a
chance a topicref with keyref attribute is present in the filtering
process.

Different from keydef, a topicref is valid with a keyref, without keys
and href attribute.

The process can't assume there is always a keys and href attribute for
only looking at the dita class "+ map/topicref mapgroup-d/keydef".