### PR TITLE
Move the nullable code into the proper else clause

### DIFF
--- a/src/main/java/org/dita/dost/reader/KeyrefReader.java
+++ b/src/main/java/org/dita/dost/reader/KeyrefReader.java
@@ -429,14 +429,15 @@ public final class KeyrefReader implements AbstractReader {
                             throw new UncheckedXPathException(e);
                         }
                     });
+                    
+                    resMeta.select(child()).forEach(child -> {
+                    	try {
+                    		receiver.append(child.getUnderlyingNode());
+                    	} catch (XPathException e) {
+                    		throw new UncheckedXPathException(e);
+                    	}
+                    });
                 }
-                resMeta.select(child()).forEach(child -> {
-                    try {
-                        receiver.append(child.getUnderlyingNode());
-                    } catch (XPathException e) {
-                        throw new UncheckedXPathException(e);
-                    }
-                });
                 receiver.endElement();
             }
 


### PR DESCRIPTION
The resMeta is nullable and there is a block of code of resMeta is
unsafe for NPE. Moved this block of code back to the ELSE block to
prevent NPE.